### PR TITLE
DB를 DATA로 이름을 수정하고 하위 호환성 유지 기능을 추가한다.

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,14 +5,27 @@ const client = new Client({ intents: [Guilds, GuildMessages, MessageContent] });
 const kiwiMode = true;
 const { token } = require(kiwiMode ? './token_kiwi.js' : './token.js');
 
-const DB = {};
+const DATA = {};
 
-DB.saveData = function(userData) {
+DATA.saveData = function(userData) {
     fs.writeFileSync(`${fileName}`, JSON.stringify(userData, null, 2));
 }
-
-DB.loadData = function() {
+DATA.loadData = function() {
     return JSON.parse(fs.readFileSync(fileName, 'utf-8'));
+}
+DATA.copyUserData = function(target) {
+    return JSON.parse(JSON.stringify(target));
+}
+DATA.getUserData = function(userId, username) {
+    if (!userData[userId]) {
+        userData[userId] = DATA.copyUserData(defualUserData);
+        userData[userId].name = username;
+        userData[userId].id = userId;
+        DATA.saveData(userData);
+    } else {
+        console.log(`유저에 대한 값이 이미 있습니다!`);
+    }
+    return userData[userId];
 }
 
 let userData = {};
@@ -20,7 +33,7 @@ let userData = {};
 const fileName = './userDataBase/userData.json';
 
 if (fs.existsSync(fileName)) {
-    userData = DB.loadData();
+    userData = DATA.loadData();
 }
 
 const defualUserData = {
@@ -28,31 +41,16 @@ const defualUserData = {
     level: 1
 }
 
-function deepCopy(target) {
-    return JSON.parse(JSON.stringify(target));
-}
-
-function getUserData(userId, username) {
-    if (!userData[userId]) {
-        userData[userId] = deepCopy(defualUserData);
-        userData[userId].name = username;
-        userData[userId].id = userId;
-        DB.saveData(userData);
-    } else {
-        console.log(`유저에 대한 값이 이미 있습니다!`);
-    }
-    return userData[userId];
-}
-
 client.on("messageCreate", async (message) => {
     if (message.author.bot) return;
     const msg = message.content.toLocaleLowerCase().trim();
     message.send = (content) => message.channel.send(content);
     const userId = message.author.id;
+    
 
     if (msg == "login") message.send(`${!!userData[message.author.id]}`);
     if (msg == 'create') {
-        getUserData(message.author.id, message.author.username);
+        DATA.getUserData(message.author.id, message.author.username);
         message.send(`작업 완료`);
     }
 
@@ -61,7 +59,7 @@ client.on("messageCreate", async (message) => {
     var user = userData[userId];
     if (msg == "hello") message.send(`hello.`);
 
-    DB.saveData(userData);
+    DATA.saveData(userData);
 });
 
 client.once('clientReady', () => console.log(kiwiMode ? 'KIWI KIWI' : 'default mode on!'));

--- a/script.js
+++ b/script.js
@@ -7,6 +7,12 @@ const { token } = require(kiwiMode ? './token_kiwi.js' : './token.js');
 
 const DATA = {};
 
+const admin = {
+    id: null,
+    name: null,
+    money: 0
+}
+
 DATA.saveData = function(userData) {
     fs.writeFileSync(`${fileName}`, JSON.stringify(userData, null, 2));
 }
@@ -18,7 +24,7 @@ DATA.copyUserData = function(target) {
 }
 DATA.getUserData = function(userId, username) {
     if (!userData[userId]) {
-        userData[userId] = DATA.copyUserData(defualUserData);
+        userData[userId] = DATA.copyUserData(admin);
         userData[userId].name = username;
         userData[userId].id = userId;
         DATA.saveData(userData);
@@ -34,11 +40,6 @@ const fileName = './userDataBase/userData.json';
 
 if (fs.existsSync(fileName)) {
     userData = DATA.loadData();
-}
-
-const defualUserData = {
-    money: 0,
-    level: 1
 }
 
 client.on("messageCreate", async (message) => {

--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ DATA.getUserData = function(userId, username) {
         userData[userId].id = userId;
         DATA.saveData(userData);
     } else {
-        console.log(`유저에 대한 값이 이미 있습니다!`);
+        // 이 유저는 객체가 이미 있다는 뜻.
     }
     return userData[userId];
 }
@@ -39,7 +39,28 @@ let userData = {};
 const fileName = './userDataBase/userData.json';
 
 if (fs.existsSync(fileName)) {
+    // 로드된 json 값들을 모두 userData에 저장하기.
     userData = DATA.loadData();
+
+    // 업데이트되었는지.
+    let isUpdated = false;
+
+    // 각 유저 객체를 하나하나 돌면서.
+    for (const userId in userData) {
+        // admin 객체의 각 프로퍼티를 확인하며 돈다.
+        for (const property in admin) {
+            // 만약 유저 객체 중 undefined와 완전히 일치하는 값이 발견되면
+            if (userData[userId][property] === undefined) {
+                // 즉시 그 undefined 값을 admin에 해당하는 값으로 채운다
+                userData[userId][property] = DATA.copyUserData[admin][property];
+                // 그리고는 유저 객체에 바뀐 값이 있다고 말하기.
+                isUpdated = true;
+            }
+        }
+    }
+
+    // 반복문에서 빠져나온 후 isUpdated 변수가 true로 되어있으면 유저 값이 바꼈다는 소리니, 유저 값들 JSON에 저장하기.
+    if (isUpdated) DATA.saveData(userData);
 }
 
 client.on("messageCreate", async (message) => {


### PR DESCRIPTION
 - `DB` 객체 이름을 `DATA`로 수정한다.
 - 깊은 복사 함수를 `DATA` 메소드로 묶는다.
 - `getUserData`함수를 `DATA` 메소드로 묶는다.
 - 업데이트로 유저 객체에 새로운 프로퍼티가 생겼을 때 하위 호환성을 위해 `if (fs.existsSync(fileName))` 조건문에서 옛버전 유저 객체에 새로운 프로퍼티를 추가하도록 한다. (하위 호환성 유지)